### PR TITLE
Add ability to aggregate resources

### DIFF
--- a/argo-cd-order/kcl.mod
+++ b/argo-cd-order/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "argo-cd-order"
-edition = "v0.1.1"
-version = "0.1.1"
+edition = "v0.1.2"
+version = "0.1.2"
 
 [dependencies]
 json_merge_patch = { oci = "oci://ghcr.io/kcl-lang/json_merge_patch", tag = "0.1.0" }

--- a/argo-cd-order/main.k
+++ b/argo-cd-order/main.k
@@ -33,13 +33,19 @@ schema ArgoCdManifestMetadataAnnotations:
     "argocd.argoproj.io/sync-wave": str
     "argocd.argoproj.io/hook": str
 
-preparePhase = lambda phase: str, phaseResources: [any] -> [ArgoCdManifest] {
-    [
+patchResource = lambda resource: any, sync_wave: str, phase: str -> ArgoCdManifest {
         p.merge(resource, { metadata.annotations = validatedAnnotations({
            "argocd.argoproj.io/sync-wave" = str(sync_wave)
            "argocd.argoproj.io/hook" = phase
         })})
-        for sync_wave, resource in phaseResources if resource != None
+}
+
+preparePhase = lambda phase: str, phaseResources: [any] -> [[ArgoCdManifest]] {
+    [
+        [
+            patchResource(resource, str(sync_wave), phase)
+            for resource in resources 
+        ] for sync_wave, resources in phaseResources if resources != None
 
     ]
 }
@@ -52,13 +58,13 @@ schema ArgoCdOrder:
     For more details: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
 
     """
-    PreSync: [any] = []
-    Sync: [any] = []
-    Skip: [any] = []
-    PostSync: [any] = []
-    SyncFail: [any] = []
+    PreSync: [any] = [[]]
+    Sync: [any] = [[]]
+    Skip: [any] = [[]]
+    PostSync: [any] = [[]]
+    SyncFail: [any] = [[]]
 
-make = lambda argoCdApp: ArgoCdOrder -> [[ArgoCdManifest]] {
+make = lambda argoCdApp: ArgoCdOrder {
     [
     preparePhase(phase, argoCdApp[phase])
         for phase in argoCdApp


### PR DESCRIPTION
ArgoCdOrder aggregates resources into batches using the same sync_wave value to run synchronization on the batch of resources in parallel mode

<!-- Thank you for contributing to KCL!

Note: 

With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
-->

#### 1. Please confirm that you have read the document before PR submitted

- [X] Yes, I have read [THIS NOTE DOC.](https://github.com/kcl-lang/modules/blob/main/README.md) 

#### 2. Contact Information(Optional)

If it is convenient, please provide your contact information so we can reach you when processing the PR:

- **Email**: ryabin.ss@gmail.com
- **HomePage**: https://github.com/metacoma
