### PR TITLE
sqlc: remove wrong unique schema.sql.rules check

### DIFF
--- a/sqlc/sqlc.k
+++ b/sqlc/sqlc.k
@@ -21,8 +21,6 @@ schema ConfigSchema:
     }
 
     check:
-        # schema.sql.rules should be unique
-        isunique(allSqlRules()), "sql.rules must be unique"
         # schema.[rulees].name should be unique
         isunique(allRuleNames()) if $rules, "rules must be unique"
         # schema.sql.[rules] need to be present in base schema.[rules].name

--- a/sqlc/sqlc_test.k
+++ b/sqlc/sqlc_test.k
@@ -293,6 +293,18 @@ sql:
         out: "some/path"
         omit_unused_structs: true
         emit_sql_as_comment: true
+  - name: "test_two"
+    schema: "schema.sql"
+    queries: "query.sql"
+    engine: "mysql"
+    rules:
+      - no-exec-q-annotation
+    gen:
+      go:
+        package: "somegopkgtwo"
+        out: "some/pathtwo"
+        omit_unused_structs: true
+        emit_sql_as_comment: true
 """
     cfg :ConfigSchema = yaml.decode(yl)
     assert len(cfg.$rules) == 1


### PR DESCRIPTION
The check was not testing for a valid case.
schema.sql.rules are not unique among multiple sql objects. This commit also adds a second sql object to test_yaml_sample in order to catch this case if rules are changed.

<!-- Thank you for contributing to KCL!

Note: 

With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
-->

#### 1. Please confirm that you have read the document before PR submitted

- [x] Yes, I have read [THIS NOTE DOC.](https://github.com/kcl-lang/modules/blob/main/README.md) 

#### 2. Contact Information(Optional)

If it is convenient, please provide your contact information so we can reach you when processing the PR:

- **Email**:
- **HomePage**:
