### PR TITLE
sqlc: add support for 'sql_driver' go gen option

### DIFF
--- a/sqlc/kcl.mod
+++ b/sqlc/kcl.mod
@@ -1,5 +1,5 @@
 [package]
 name = "sqlc"
 edition = "v0.9.0"
-version = "0.0.3"
+version = "0.0.4"
 description = "sqlc.dev schema config file"

--- a/sqlc/sqlc.k
+++ b/sqlc/sqlc.k
@@ -167,6 +167,10 @@ schema GoGen:
     # Either `pgx/v4`, `pgx/v5` or `database/sql`.
     # Defaults to database/sql.
     sql_package: "database/sql" | "pgx/v4" | "pgx/v5" = "database/sql"
+    # One of the following drivers are allowed, the default value will depend on the sql_package
+    # and is handled by sqlc behavior:
+    # "github.com/jackc/pgx/v4" | "github.com/jackc/pgx/v5" | "github.com/lib/pq" | "github.com/go-sql-driver/mysql"
+    sql_driver?: "github.com/jackc/pgx/v4" | "github.com/jackc/pgx/v5" | "github.com/lib/pq" | "github.com/go-sql-driver/mysql"
     # If true, add DB tags to generated structs. Defaults to false.
     emit_db_tags: bool = False
     # If true, include support for prepared queries. Defaults to false.

--- a/sqlc/sqlc_test.k
+++ b/sqlc/sqlc_test.k
@@ -293,6 +293,7 @@ sql:
         out: "some/path"
         omit_unused_structs: true
         emit_sql_as_comment: true
+        sql_driver: "github.com/go-sql-driver/mysql"
   - name: "test_two"
     schema: "schema.sql"
     queries: "query.sql"


### PR DESCRIPTION
sqlc lacks documentation on sql_driver setting
however setting is referenced in multiple places in their documentation the inputs and validation was done based on the latest sqlc code v1.27.0

See the following issue created in sqlc repo: 
- https://github.com/sqlc-dev/sqlc/issues/3582

<!-- Thank you for contributing to KCL!

Note: 

With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
-->

#### 1. Please confirm that you have read the document before PR submitted

- [x] Yes, I have read [THIS NOTE DOC.](https://github.com/kcl-lang/modules/blob/main/README.md) 

#### 2. Contact Information(Optional)

If it is convenient, please provide your contact information so we can reach you when processing the PR:

- **Email**:
- **HomePage**:
