### PR TITLE
Yds/fix queries types

### DIFF
--- a/sqlc/kcl.mod
+++ b/sqlc/kcl.mod
@@ -1,5 +1,5 @@
 [package]
 name = "sqlc"
 edition = "v0.9.0"
-version = "0.0.4"
+version = "0.0.5"
 description = "sqlc.dev schema config file"

--- a/sqlc/sqlc.k
+++ b/sqlc/sqlc.k
@@ -70,7 +70,7 @@ schema ConfigSql:
     # Directory of SQL migrations or path to single SQL file; or a list of paths.
     $schema: str
     # Directory of SQL queries or path to single SQL file; or a list of paths.
-    queries?: str
+    queries?: str|[str]
     # A collection of mappings to configure code generators.
     # See codegen for the supported keys.
     # https://docs.sqlc.dev/en/latest/reference/config.html#codegen


### PR DESCRIPTION
Configuration for sqlc support both "path" and ["path1", "path2"] as part of queries
This enables queries field to support either type as expected by sqlc configuration.


#### 1. Please confirm that you have read the document before PR submitted

- [x] Yes, I have read [THIS NOTE DOC.](https://github.com/kcl-lang/modules/blob/main/README.md) 

#### 2. Contact Information(Optional)

You can join me throuhg yvan@yakika.com or ping me via github notifications.