### PR TITLE
feat(gke): add gpuSharing field to ComputeClass GPU spec

### DIFF
--- a/gke/kcl.mod
+++ b/gke/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "gke"
-edition = "v0.11.3"
-version = "0.0.3"
+edition = "v0.11.4"
+version = "0.0.4"
 
 [dependencies]
 k8s = "1.32.4"

--- a/gke/v1/cloud_google_com_v1_compute_class.k
+++ b/gke/v1/cloud_google_com_v1_compute_class.k
@@ -245,6 +245,40 @@ schema CloudGoogleComV1ComputeClassSpecPrioritiesItems0:
         minMemoryGb >= 0 if minMemoryGb not in [None, Undefined]
 
 
+schema CloudGoogleComV1ComputeClassSpecPrioritiesItems0GpuSharing:
+    r"""
+    GpuSharing defines GPU sharing and partitioning config for a node.
+    Requires GKE version 1.35.2-gke.1485000 or later.
+
+    Attributes
+    ----------
+    sharingStrategy : str, default is Undefined, optional
+        SharingStrategy describes the GPU sharing strategy.
+        Supported values: TIME_SHARING, MPS.
+    maxSharedClientsPerGPU : int, default is Undefined, optional
+        MaxSharedClientsPerGPU describes the maximum number of containers
+        that can share a GPU. Valid range: 2-48.
+        Required when sharingStrategy is set.
+    gpuPartitionSize : str, default is Undefined, optional
+        GpuPartitionSize enables multi-instance GPU (MIG) partitioning.
+        Sets the MIG profile applied to each GPU on the node.
+        Example values for nvidia-rtx-pro-6000: "1g.24gb", "2g.48gb", "4g.96gb".
+        Example values for nvidia-h100-80gb: "1g.10gb", "2g.20gb", "3g.40gb", "4g.40gb", "7g.80gb".
+        If omitted the GPU is not partitioned.
+    """
+
+    sharingStrategy?: str
+
+    maxSharedClientsPerGPU?: int
+
+    gpuPartitionSize?: str
+
+
+    check:
+        maxSharedClientsPerGPU >= 2 if maxSharedClientsPerGPU not in [None, Undefined]
+        maxSharedClientsPerGPU <= 48 if maxSharedClientsPerGPU not in [None, Undefined]
+
+
 schema CloudGoogleComV1ComputeClassSpecPrioritiesItems0Gpu:
     r"""
     Gpu defines preferred GPU config for a node.
@@ -257,6 +291,9 @@ schema CloudGoogleComV1ComputeClassSpecPrioritiesItems0Gpu:
         DriverVersion describes version of GPU driver for a node.
     $type : str, default is Undefined, optional
         Type describes preferred GPU accelerator type for a node.
+    gpuSharing : CloudGoogleComV1ComputeClassSpecPrioritiesItems0GpuSharing, default is Undefined, optional
+        GpuSharing configures GPU sharing strategies and MIG partitioning.
+        Requires GKE version 1.35.2-gke.1485000 or later.
     """
 
 
@@ -265,6 +302,8 @@ schema CloudGoogleComV1ComputeClassSpecPrioritiesItems0Gpu:
     driverVersion?: "default" | "latest" = "default"
 
     $type?: str
+
+    gpuSharing?: CloudGoogleComV1ComputeClassSpecPrioritiesItems0GpuSharing
 
 
     check:


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
-->

#### 1. Please confirm that you have read the document before PR submitted

- [x] Yes, I have read [THIS NOTE DOC.](https://github.com/kcl-lang/modules/blob/main/README.md) 

#### 2. Contact Information(Optional)

If it is convenient, please provide your contact information so we can reach you when processing the PR:

- **Email**: bellemare.david@gmail.com
- **HomePage**:

---

## What does this PR do?

Adds `gpuSharing` support to the `spec.priorities[].gpu` field of the GKE `ComputeClass` CRD schema.

GKE 1.35.2-gke.1485000 introduced a `gpuSharing` object under the GPU section that enables:
- **Time-sharing / MPS** — multiple containers share a single physical GPU
- **MIG partitioning** — the GPU is split into isolated multi-instance partitions (`gpuPartitionSize`)

Without this change, any `ComputeClass` that uses `gpuSharing` fails KCL schema validation with an unknown-attribute error.

### New schema

A new `CloudGoogleComV1ComputeClassSpecPrioritiesItems0GpuSharing` schema is added:

| Field | Type | Description |
|---|---|---|
| `sharingStrategy` | `str` | `TIME_SHARING` or `MPS` |
| `maxSharedClientsPerGPU` | `int` | 2–48; required with a sharing strategy |
| `gpuPartitionSize` | `str` | MIG profile, e.g. `"1g.24gb"`. Omit to skip partitioning. |

### Example

```python
priorities = [
    {
        gpu = {
            count = 1
            driverVersion = "latest"
            type = "nvidia-rtx-pro-6000"
            gpuSharing = {
                gpuPartitionSize = "1g.24gb"
            }
        }
        machineType = "g4-standard-48"
    }
]
```

**Ref:** https://cloud.google.com/kubernetes-engine/docs/reference/crds/computeclass