### PR TITLE
fix(ci): use docker.io as ORAS auth key

### DIFF
--- a/.github/workflows/update_metadata.yaml
+++ b/.github/workflows/update_metadata.yaml
@@ -41,6 +41,10 @@ jobs:
       # `OCI_REG_PLAIN_HTTP=on` is set — and that flag also forces the
       # registry to plain HTTP, which breaks HTTPS-only registries like
       # docker.io and ghcr.io. See issue #378.
+      #
+      # ORAS's credential lookup uses the hostname as the key (e.g. `docker.io`)
+      # and matches it against the auths map. We also include the legacy
+      # `https://index.docker.io/v1/` key as a fallback for older code paths.
       - name: Configure kpm credentials
         run: |
           mkdir -p "$HOME/.kpm/config"
@@ -49,11 +53,14 @@ jobs:
           cat > "$HOME/.kpm/config/config.json" <<EOF
           {
             "auths": {
-              "https://index.docker.io/v1/": { "auth": "${DOCKER_AUTH}" },
-              "ghcr.io":                       { "auth": "${GHCR_AUTH}" }
+              "docker.io":                       { "auth": "${DOCKER_AUTH}" },
+              "https://index.docker.io/v1/":      { "auth": "${DOCKER_AUTH}" },
+              "ghcr.io":                         { "auth": "${GHCR_AUTH}" }
             }
           }
           EOF
+          echo "Wrote credentials to $HOME/.kpm/config/config.json"
+          cat "$HOME/.kpm/config/config.json" | sed 's/"auth": "[^"]*"/"auth": "<redacted>"/'
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/update_specified_metadatas.yaml
+++ b/.github/workflows/update_specified_metadatas.yaml
@@ -41,6 +41,10 @@ jobs:
       # `OCI_REG_PLAIN_HTTP=on` is set — and that flag also forces the
       # registry to plain HTTP, which breaks HTTPS-only registries like
       # docker.io and ghcr.io. See issue #378.
+      #
+      # ORAS's credential lookup uses the hostname as the key (e.g. `docker.io`)
+      # and matches it against the auths map. We also include the legacy
+      # `https://index.docker.io/v1/` key as a fallback for older code paths.
       - name: Configure kpm credentials
         run: |
           mkdir -p "$HOME/.kpm/config"
@@ -49,11 +53,14 @@ jobs:
           cat > "$HOME/.kpm/config/config.json" <<EOF
           {
             "auths": {
-              "https://index.docker.io/v1/": { "auth": "${DOCKER_AUTH}" },
-              "ghcr.io":                       { "auth": "${GHCR_AUTH}" }
+              "docker.io":                       { "auth": "${DOCKER_AUTH}" },
+              "https://index.docker.io/v1/":      { "auth": "${DOCKER_AUTH}" },
+              "ghcr.io":                         { "auth": "${GHCR_AUTH}" }
             }
           }
           EOF
+          echo "Wrote credentials to $HOME/.kpm/config/config.json"
+          cat "$HOME/.kpm/config/config.json" | sed 's/"auth": "[^"]*"/"auth": "<redacted>"/'
 
       # Republish to docker.io. `continue-on-error` plus `if: always()` on the
       # ghcr.io step ensures a docker.io failure can no longer skip the


### PR DESCRIPTION
## Summary

The previous fix (#380) wrote the credentials under `https://index.docker.io/v1/`, but ORAS's credential lookup uses the hostname (`docker.io`) as the key. The legacy URL key only matches `index.docker.io` lookups, not `docker.io` lookups — which is what kpm uses. So the push still failed with HTTP 401 unauthorized.

This PR:
- Adds `docker.io` as the primary key (matches what kpm looks up).
- Keeps `https://index.docker.io/v1/` as a fallback for older code paths.
- Adds a `cat` of the config file with the `auth` value redacted, so the file content is visible in the workflow log for debugging.

Fixes #378.

## Test plan

- [ ] Trigger `update_specified_metadatas.yaml` with `myInput=enkinex-odcs` after this PR is merged and verify the push succeeds.
- [ ] Verify:
  ```bash
  curl -s -o /dev/null -w '%{http_code}\n' \
    "https://ghcr.io/token?scope=repository%3Akcl-lang%2Fenkinex-odcs%3Apull&service=ghcr.io"
  # expect 200
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)