### PR TITLE
fix(ci): use docker/login-action for kpm push auth

### DIFF
--- a/.github/workflows/update_specified_metadatas.yaml
+++ b/.github/workflows/update_specified_metadatas.yaml
@@ -34,33 +34,31 @@ jobs:
       - name: Install kpm
         run: go install kcl-lang.io/kpm@latest
 
-      # Write credentials directly into kpm's config file
-      # (~/.kpm/config/config.json) in the standard Docker `auths` format.
+      # Authenticate to docker.io and ghcr.io via the standard Docker
+      # credential helper chain (`docker/login-action`). kpm's credential
+      # store falls back to `~/.docker/config.json` when its own
+      # `~/.kpm/config/config.json` returns empty, so this populates the
+      # fallback store correctly on GitHub Actions runners that ship a
+      # credential helper that blocks plaintext storage.
+      #
       # `kpm login` cannot be used here because the underlying ORAS store
       # requires `AllowPlaintextPut: true`, which is only enabled when
       # `OCI_REG_PLAIN_HTTP=on` is set — and that flag also forces the
       # registry to plain HTTP, which breaks HTTPS-only registries like
       # docker.io and ghcr.io. See issue #378.
-      #
-      # ORAS's credential lookup uses the hostname as the key (e.g. `docker.io`)
-      # and matches it against the auths map. We also include the legacy
-      # `https://index.docker.io/v1/` key as a fallback for older code paths.
-      - name: Configure kpm credentials
-        run: |
-          mkdir -p "$HOME/.kpm/config"
-          DOCKER_AUTH=$(printf '%s:%s' "${{ secrets.DOCKER_USERNAME }}" "${{ secrets.DOCKER_PASSWORD }}" | base64 -w0)
-          GHCR_AUTH=$(printf '%s:%s' "${{ secrets.DEPLOY_ACCESS_NAME }}" "${{ secrets.DEPLOY_ACCESS_TOKEN }}" | base64 -w0)
-          cat > "$HOME/.kpm/config/config.json" <<EOF
-          {
-            "auths": {
-              "docker.io":                       { "auth": "${DOCKER_AUTH}" },
-              "https://index.docker.io/v1/":      { "auth": "${DOCKER_AUTH}" },
-              "ghcr.io":                         { "auth": "${GHCR_AUTH}" }
-            }
-          }
-          EOF
-          echo "Wrote credentials to $HOME/.kpm/config/config.json"
-          cat "$HOME/.kpm/config/config.json" | sed 's/"auth": "[^"]*"/"auth": "<redacted>"/'
+      - name: Login to docker.io
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DEPLOY_ACCESS_NAME }}
+          password: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
 
       # Republish to docker.io. `continue-on-error` plus `if: always()` on the
       # ghcr.io step ensures a docker.io failure can no longer skip the


### PR DESCRIPTION
Switch from manual ~/.kpm/config/config.json writing to docker/login-action. kpm's WithFallbacks credential store will read ~/.docker/config.json when ~/.kpm/config/config.json returns empty. docker/login-action handles GitHub Actions credential helper quirks correctly.

Refs: kcl-lang/modules#378