### PR TITLE
fix(ci): use OCI_REG_PLAIN_HTTP for local plain-HTTP registry tests (#384)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,4 +23,14 @@ jobs:
       run: go get -v -t -d ./...
 
     - name: Test
+      # Pin a shared kpm config dir so the `kcl registry login` invoked
+      # by Integrate-Checksum/TestMainFunc → mock/test_script/{push,pull}_pkg.sh
+      # (which installs the latest kcl and therefore uses the kpm v0.12.x
+      # default of $XDG_DATA_HOME/kcl/modules) writes credentials to the
+      # same place that the in-process kpmClient (kpm v0.11.1 from go.mod,
+      # defaulting to ~/.kcl/kpm) reads from. Without this, the Go test
+      # reports "basic credential not found" because the two processes
+      # disagree on where the credential file lives.
+      env:
+        KCL_PKG_PATH: /tmp/kcl-modules-test-kpm
       run: go test -v ./...

--- a/.github/workflows/test_publish.yaml
+++ b/.github/workflows/test_publish.yaml
@@ -30,13 +30,16 @@ jobs:
           KPM_REG: "localhost:5001"
           KPM_REPO: "test"
           LOGIN_WITH_KCL: "1"
+          # Local registry is plain HTTP (no TLS), so kcl registry login /
+          # kcl mod push must use plain HTTP transport — otherwise the
+          # HTTPS dial fails with: http: server gave HTTP response to
+          # HTTPS client. `--insecure-skip-tls-verify` alone does not
+          # help: it only disables certificate verification, not the
+          # scheme. See issues #378 and #384.
+          OCI_REG_PLAIN_HTTP: "on"
         run: |
           ./scripts/reg.sh
-          # Local registry is plain HTTP (no TLS), so we must skip TLS
-          # verification when storing credentials — otherwise `kcl registry
-          # login` fails with: http: server gave HTTP response to HTTPS
-          # client. See issue #378.
-          kcl registry login --insecure-skip-tls-verify -u test -p 1234 localhost:5001
+          kcl registry login -u test -p 1234 localhost:5001
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             ./scripts/push_pkg_from.sh $file
           done

--- a/mock/test_script/pull_pkg.sh
+++ b/mock/test_script/pull_pkg.sh
@@ -18,6 +18,11 @@ fi
 
 export KPM_REG="localhost:5001"
 export KPM_REPO="test"
+# The local registry started by scripts/reg.sh is plain HTTP (no TLS).
+# OCI_REG_PLAIN_HTTP=on forces kcl/kpm to use plain HTTP transport,
+# otherwise kcl registry login fails with: http: server gave HTTP
+# response to HTTPS client. See issue #384.
+export OCI_REG_PLAIN_HTTP="on"
 
 # Prepare the package on the registry
 current_dir=$(pwd)

--- a/mock/test_script/push_pkg.sh
+++ b/mock/test_script/push_pkg.sh
@@ -18,6 +18,11 @@ fi
 
 export KPM_REG="localhost:5001"
 export KPM_REPO="test"
+# The local registry started by scripts/reg.sh is plain HTTP (no TLS).
+# OCI_REG_PLAIN_HTTP=on forces kcl/kpm to use plain HTTP transport,
+# otherwise kcl registry login fails with: http: server gave HTTP
+# response to HTTPS client. See issue #384.
+export OCI_REG_PLAIN_HTTP="on"
 
 # Prepare the package on the registry
 current_dir=$(pwd)


### PR DESCRIPTION
## Summary

Fixes #384 (and a related failure in the Test Generate Metadata workflow).

The local registry started by `scripts/reg.sh` is plain HTTP (no TLS).
`kcl registry login` dials `https://...` by default, so it always fails
with `http: server gave HTTP response to HTTPS client` regardless of the
`--insecure-skip-tls-verify` flag (which only disables certificate
verification, not the URL scheme).

The correct setting for this job is `OCI_REG_PLAIN_HTTP=on`, which forces
kcl/kpm to use plain HTTP transport for both login and push.

## Changes

- `.github/workflows/test_publish.yaml`: add `OCI_REG_PLAIN_HTTP: "on"` to
  the test job's env, drop the now-redundant `--insecure-skip-tls-verify`
  flag, update the comment to reference both #378 and #384.
- `mock/test_script/push_pkg.sh`: `export OCI_REG_PLAIN_HTTP=on` before
  the `kcl registry login` call.
- `mock/test_script/pull_pkg.sh`: same.

The Go test changes are necessary because the **Test Generate Metadata**
workflow (`test.yaml`) runs `go test -v ./...`, which executes
`Integrate-Checksum/TestMainFunc`. That test starts the same plain-HTTP
registry and then calls `mock.PushTestPkgToRegistry()` ->
`mock/test_script/push_pkg.sh`, which fails at `kcl registry login` for
the same reason as #384. The test ran on every PR that touched `**.mod`
and was the last red step on the recent PR #382 chain.

## Why this is scoped to the test job

`OCI_REG_PLAIN_HTTP=on` is correct **only** for the local-registry
test job and the Go test that drives the same registry. It must not be
applied to `update_metadata.yaml` / `update_specified_metadatas.yaml`,
since `docker.io` and `ghcr.io` are HTTPS-only — exactly the trade-off
already documented in the comments added for #378.

## Test plan

- [ ] `Test Generate Metadata` workflow on this PR should pass
  (`TestMainFunc` in `Integrate-Checksum`).
- [ ] `Test Publish Package` workflow should pass when this branch is
  pushed to a PR that touches a `*.mod` file (issue #384's repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)