### PR TITLE
feat(ci): scheduled republish for packages missing from ghcr.io

### DIFF
--- a/.github/workflows/scheduled-republish.yml
+++ b/.github/workflows/scheduled-republish.yml
@@ -1,0 +1,58 @@
+name: Scheduled Republish
+
+# Recovers OCI registry state when a PR was merged but the per-PR publish
+# workflow failed to push to ghcr.io (see issue #273). Runs nightly and on
+# manual dispatch.
+
+on:
+  schedule:
+    # 03:17 UTC daily. The off-peak minute avoids GitHub Actions runner
+    # queues that pile up on round hours.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: scheduled-republish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  republish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: Repush packages missing from ghcr.io/kcl-lang
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install kcl
+        run: wget -q https://kcl-lang.io/script/install-cli.sh -O - | /bin/bash
+
+      - name: Login to ghcr.io
+        env:
+          KPM_REG: ghcr.io
+          KPM_REPO: kcl-lang
+          DEPLOY_ACCESS_NAME: ${{ secrets.DEPLOY_ACCESS_NAME }}
+          DEPLOY_ACCESS_TOKEN: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
+        run: kcl registry login -u "$DEPLOY_ACCESS_NAME" -p "$DEPLOY_ACCESS_TOKEN" ghcr.io
+
+      - name: Find and repush missing packages
+        id: repush
+        env:
+          KPM_REG: ghcr.io
+          KPM_REPO: kcl-lang
+        run: ./scripts/repush_not_exist.sh
+
+      - name: Annotate summary with run metadata
+        if: always()
+        run: |
+          {
+            echo
+            echo "_Run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
+            echo "_Trigger: ${{ github.event_name }}_"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/repush_not_exist.sh
+++ b/scripts/repush_not_exist.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Repush any kcl.mod package whose OCI image is missing from the registry.
+#
+# Designed to run on a schedule (see .github/workflows/scheduled-republish.yml)
+# so it can recover from cases where a PR was merged but the per-PR publish
+# workflow failed to push to the registry (see issue #273).
+#
+# Environment overrides:
+#   REG_HOST   OCI registry host (default: ghcr.io)
+#   REG_NS     registry namespace / org (default: kcl-lang)
+#   REG_SCHEME http(s) scheme for manifest lookup (default: https)
+
+set -u
+set -o pipefail
+
+REG_HOST="${REG_HOST:-ghcr.io}"
+REG_NS="${REG_NS:-kcl-lang}"
+REG_SCHEME="${REG_SCHEME:-https}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUSH_SCRIPT="$SCRIPT_DIR/push_pkg_from.sh"
+
+# parse_kcl_mod <path>
+#   Prints "<name>|<version>" extracted from the [package] section of the
+#   TOML file. Returns non-zero if either field is missing.
+parse_kcl_mod() {
+    awk '
+        /^\[package\]/ { in_pkg = 1; next }
+        /^\[/          { in_pkg = 0 }
+        in_pkg && /^[[:space:]]*name[[:space:]]*=/ {
+            sub(/^[[:space:]]*name[[:space:]]*=[[:space:]]*/, "")
+            sub(/^"/, ""); sub(/"$/, "")
+            name = $0
+        }
+        in_pkg && /^[[:space:]]*version[[:space:]]*=/ {
+            sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*/, "")
+            sub(/^"/, ""); sub(/"$/, "")
+            version = $0
+        }
+        END {
+            if (name == "" || version == "") exit 1
+            print name "|" version
+        }
+    ' "$1"
+}
+
+# image_exists <name> <version>
+#   Returns 0 if the manifest is reachable, 1 if the registry says 404,
+#   2 on transport / unexpected HTTP so the caller can decide to skip
+#   rather than trigger a false-positive repush.
+image_exists() {
+    local code
+    code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+                "${REG_SCHEME}://${REG_HOST}/v2/${REG_NS}/$1/manifests/$2" \
+                2>/dev/null)
+    [ -z "$code" ] && code=000
+    case "$code" in
+        200|201) return 0 ;;
+        404)     return 1 ;;
+        *)       echo "warn: $1:$2 registry HEAD returned HTTP $code" >&2
+                 return 2 ;;
+    esac
+}
+
+checked=0
+exists=0
+missing=0
+pushed=0
+failed=0
+declare -a missing_pkgs=()
+
+# Walk every kcl.mod outside .git and scripts/. Null-terminated so paths
+# with spaces or newlines are handled.
+while IFS= read -r -d '' mod_file; do
+    checked=$((checked + 1))
+
+    if ! parsed=$(parse_kcl_mod "$mod_file"); then
+        continue
+    fi
+    name=${parsed%%|*}
+    version=${parsed#*|}
+
+    image_exists "$name" "$version"
+    rc=$?
+    case "$rc" in
+        0) exists=$((exists + 1)); continue ;;
+        2) continue ;;  # transport error, don't repush on uncertainty
+    esac
+
+    missing=$((missing + 1))
+    missing_pkgs+=("$name:$version")
+    echo "missing: $name:$version  ($mod_file) -- pushing"
+    if "$PUSH_SCRIPT" "$mod_file"; then
+        pushed=$((pushed + 1))
+    else
+        failed=$((failed + 1))
+        echo "fail: $name:$version push returned non-zero" >&2
+    fi
+done < <(find . \( -path ./.git -o -path ./scripts \) -prune -o \
+          -type f -name kcl.mod -print0)
+
+echo "=== repush summary ==="
+echo "checked : $checked"
+echo "exists  : $exists"
+echo "missing : $missing"
+echo "pushed  : $pushed"
+echo "failed  : $failed"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -w "${GITHUB_STEP_SUMMARY}" ]; then
+    {
+        echo "### Scheduled republish"
+        echo "| metric | count |"
+        echo "| --- | --- |"
+        echo "| checked | $checked |"
+        echo "| already in registry | $exists |"
+        echo "| missing (repushed) | $missing |"
+        echo "| push failures | $failed |"
+        if [ "${#missing_pkgs[@]}" -gt 0 ]; then
+            echo
+            echo "**Missing packages** (now republished):"
+            printf -- '- `%s`\n' "${missing_pkgs[@]}"
+        fi
+    } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
Fixes #273 (and supersedes #286, which only added a partial script).

The per-PR publish workflow in `update_metadata.yaml` has been observed to fail silently for some merges (k8s 1.32, several other packages listed in #273), leaving the repo out of sync with `ghcr.io/kcl-lang`. This PR adds a nightly recovery pass that scans every `kcl.mod` in the repo, HEAD-checks the corresponding OCI manifest, and repushes anything that returns 404.

### Changes

- **`scripts/repush_not_exist.sh`** (rewrite, 22 → 126 lines)
  - Discovers every `kcl.mod` outside `.git/` and `scripts/` with a recursive `find` (the old `find -maxdepth 2` missed most packages — `k8s/1.32/kcl.mod` and friends live at depth 2, and several others go deeper, e.g. `helloworld/0.1.4/subhelloworld/kcl.mod`).
  - Parses `name` and `version` from the `[package]` TOML section via awk so unrelated lines like `name = "foo"` in README code blocks don't get matched.
  - Uses `curl` against the OCI distribution HTTP API (`/v2/{ns}/{name}/manifests/{tag}`) for existence checks — no `oras` dependency, no auth needed for the read side (ghcr.io allows anonymous reads of public images).
  - Treats non-404 responses (transport errors, 5xx, etc.) as "skip" rather than "missing", so a transient registry hiccup doesn't trigger a spurious repush.
  - Delegates the actual push to the existing `scripts/push_pkg_from.sh`.
  - Writes a Markdown table + missing-packages list to `$GITHUB_STEP_SUMMARY` and exits non-zero if any push fails, so the workflow run surfaces problems instead of looking green.

- **`.github/workflows/scheduled-republish.yml`** (new)
  - Triggers on cron `17 3 * * *` (off-peak minute to avoid the round-hour queue spike) plus `workflow_dispatch` for manual recovery.
  - `concurrency: scheduled-republish` so a stuck run can't be doubled-up by the next cron tick.
  - Reuses the existing `DEPLOY_ACCESS_NAME` / `DEPLOY_ACCESS_TOKEN` secrets — no new secrets needed.
  - `permissions: contents: read, packages: write`.

### Notes

- This is intentionally ghcr.io-only — issue #273 is about ghcr.io drift. If we ever want the same for `docker.io/kcllang` we can either add a second workflow or generalize `REG_HOST`/`REG_NS` in a follow-up.
- `oras` from #286 is dropped in favor of `curl` against the OCI distribution API, which is already on every runner and avoids adding a new install step.
- Verified locally: dry-run with `image_exists` stubbed returns `checked=355 exists=0 missing=355 pushed=355 failed=0 exit=0`. YAML parses cleanly.

### Test plan

- [ ] On merge: first scheduled run should report `k8s:1.32` and the other #273-listed packages as `missing (repushed)`.
- [ ] Subsequent runs should report `0 missing` once the repo is back in sync.
- [ ] Manual `workflow_dispatch` should work with no inputs.