### PR TITLE
fix(ci): repair scheduled republish and stop artifacthub metadata push races (fixes #395)

### DIFF
--- a/.github/workflows/scheduled-republish.yml
+++ b/.github/workflows/scheduled-republish.yml
@@ -33,13 +33,38 @@ jobs:
       - name: Install kcl
         run: wget -q https://kcl-lang.io/script/install-cli.sh -O - | /bin/bash
 
-      - name: Login to ghcr.io
+      # Write ghcr.io credentials into BOTH (same workaround as the
+      # "Publish Package" workflow, see #397 and issue #378):
+      #   * `~/.docker/config.json` (the file ORAS reads by default)
+      #   * `~/.kpm/config/config.json` (the file kpm's own store reads)
+      #
+      # `kcl registry login` cannot be used here. On a headless CI runner
+      # there is no credential helper (no keyring), so the ORAS store it
+      # backs onto refuses to persist credentials and the command fails
+      # with "putting plaintext credentials is disabled" (the nightly run
+      # linked in issue #395). kpm only enables ORAS's
+      # `AllowPlaintextPut: true` when `OCI_REG_PLAIN_HTTP=on` is set,
+      # and that flag also forces plain-HTTP transport, which does not
+      # work against HTTPS-only registries like ghcr.io.
+      - name: Configure registry credentials
         env:
-          KPM_REG: ghcr.io
-          KPM_REPO: kcl-lang
           DEPLOY_ACCESS_NAME: ${{ secrets.DEPLOY_ACCESS_NAME }}
           DEPLOY_ACCESS_TOKEN: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
-        run: kcl registry login -u "$DEPLOY_ACCESS_NAME" -p "$DEPLOY_ACCESS_TOKEN" ghcr.io
+        run: |
+          mkdir -p "$HOME/.docker" "$HOME/.kpm/config"
+          GHCR_AUTH=$(printf '%s:%s' "$DEPLOY_ACCESS_NAME" "$DEPLOY_ACCESS_TOKEN" | base64 -w0)
+
+          cat > "$HOME/.docker/config.json" <<EOF
+          {
+            "auths": {
+              "ghcr.io": { "auth": "${GHCR_AUTH}" }
+            }
+          }
+          EOF
+
+          cp "$HOME/.docker/config.json" "$HOME/.kpm/config/config.json"
+
+          echo "Wrote ghcr.io credentials to $HOME/.docker/config.json and $HOME/.kpm/config/config.json"
 
       - name: Find and repush missing packages
         id: repush

--- a/.github/workflows/update_metadata.yaml
+++ b/.github/workflows/update_metadata.yaml
@@ -11,6 +11,18 @@ env:
   KPM_REG: "docker.io"
   KPM_REPO: "kcllang"
 
+# Serialize publish runs. When several PRs touching *.mod merge in quick
+# succession, each push triggers a run, and every run commits its
+# artifacthub-pkg.yaml changes back to main. Without this group the runs
+# race on `git push` and every one of them gets rejected with
+# "! [rejected] main -> main (fetch first)" — the metadata commits are
+# then silently lost and Artifact Hub never learns about the new versions
+# (see issue #395). cancel-in-progress is false on purpose: a cancelled
+# run would skip the very publish it was created for.
+concurrency:
+  group: publish-package
+  cancel-in-progress: false
+
 jobs:
   publish_pkg:
     # NOTE:
@@ -165,5 +177,12 @@ jobs:
 
             git add .
             git commit -m "chore: update artifacthub-pkg.yaml" || echo "Nothing to commit"
+
+            # main may have moved since checkout (e.g. a previous publish
+            # run in the same concurrency group already pushed its metadata
+            # commit, or another workflow pushed). Rebase our metadata
+            # commit on top before pushing, otherwise the push is rejected
+            # with "fetch first" and the commit is lost (issue #395).
+            git pull --rebase origin main
             git push
           fi

--- a/.github/workflows/update_specified_metadatas.yaml
+++ b/.github/workflows/update_specified_metadatas.yaml
@@ -12,6 +12,12 @@ env:
   KPM_REG: "docker.io"
   KPM_REPO: "kcllang"
 
+# Same group as the "Publish Package" workflow: both commit regenerated
+# artifacthub-pkg.yaml files back to main and must not race on `git push`.
+concurrency:
+  group: publish-package
+  cancel-in-progress: false
+
 jobs:
   publish_pkg:
     # NOTE:
@@ -126,4 +132,9 @@ jobs:
 
           git add .
           git commit -m "Regenerate artifacthub-pkg.yaml for all packages" || echo "Nothing to commit"
+
+          # main may have moved since checkout (see the "Publish Package"
+          # workflow) — rebase before pushing or the push is rejected
+          # with "fetch first" and the commit is lost (issue #395).
+          git pull --rebase origin main
           git push

--- a/scripts/repush_not_exist.sh
+++ b/scripts/repush_not_exist.sh
@@ -20,6 +20,13 @@ REG_SCHEME="${REG_SCHEME:-https}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUSH_SCRIPT="$SCRIPT_DIR/push_pkg_from.sh"
 
+TMP_HDR=$(mktemp)
+trap 'rm -f "$TMP_HDR"' EXIT
+
+# Manifest media types kpm may push. Without a proper Accept header ghcr.io
+# answers 404 even for existing tags (it cannot pick a representation).
+ACCEPT="application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json"
+
 # parse_kcl_mod <path>
 #   Prints "<name>|<version>" extracted from the [package] section of the
 #   TOML file. Returns non-zero if either field is missing.
@@ -45,19 +52,59 @@ parse_kcl_mod() {
 }
 
 # image_exists <name> <version>
-#   Returns 0 if the manifest is reachable, 1 if the registry says 404,
-#   2 on transport / unexpected HTTP so the caller can decide to skip
-#   rather than trigger a false-positive repush.
+#   Returns 0 if the manifest is reachable, 1 if the package/tag is not
+#   in the registry, 2 on transport / unexpected HTTP so the caller can
+#   decide to skip rather than trigger a false-positive repush.
+#
+#   ghcr.io (and other OCI registries) answer anonymous manifest requests
+#   with 401 + a WWW-Authenticate bearer challenge even for public
+#   packages, and return 401 for both existing and missing tags — a bare
+#   probe therefore cannot distinguish anything. Follow the challenge to
+#   obtain an anonymous pull token and re-probe with it. A denied token
+#   request (ghcr.io: HTTP 403, body {"errors":[{"code":"DENIED"}]} for a
+#   nonexistent repository) also counts as missing: every package in this
+#   org is public, so an inaccessible repo is a repo that is not there.
 image_exists() {
-    local code
+    local name="$1" version="$2"
+    local url="${REG_SCHEME}://${REG_HOST}/v2/${REG_NS}/$1/manifests/$2"
+    local code auth_header realm service token_url token
+
+    code=$(curl -sS -o /dev/null -D "$TMP_HDR" -w '%{http_code}' --max-time 30 \
+                -H "Accept: ${ACCEPT}" "$url" 2>/dev/null) || code=000
+    [ -z "$code" ] && code=000
+
+    case "$code" in
+        200|201) return 0 ;;
+        404)     return 1 ;;
+        401)     ;; # anonymous bearer challenge, resolved below
+        *)       echo "warn: $1:$2 registry probe returned HTTP $code" >&2
+                 return 2 ;;
+    esac
+
+    auth_header=$(tr -d '\r' < "$TMP_HDR" \
+                      | awk 'tolower($1)=="www-authenticate:" {$1=""; print; exit}')
+    realm=$(printf '%s\n' "$auth_header" | sed -n 's/.*realm="\([^"]*\)".*/\1/p')
+    if [ -z "$realm" ]; then
+        echo "warn: $1:$2 got HTTP 401 without a WWW-Authenticate bearer challenge" >&2
+        return 2
+    fi
+    service=$(printf '%s\n' "$auth_header" | sed -n 's/.*service="\([^"]*\)".*/\1/p')
+
+    token_url="${realm}?service=${service}&scope=repository:${REG_NS}/${name}:pull"
+    token=$(curl -sS --max-time 30 "$token_url" 2>/dev/null \
+                | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    if [ -z "$token" ]; then
+        return 1
+    fi
+
     code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-                "${REG_SCHEME}://${REG_HOST}/v2/${REG_NS}/$1/manifests/$2" \
-                2>/dev/null)
+                -H "Authorization: Bearer $token" -H "Accept: ${ACCEPT}" \
+                "$url" 2>/dev/null) || code=000
     [ -z "$code" ] && code=000
     case "$code" in
         200|201) return 0 ;;
         404)     return 1 ;;
-        *)       echo "warn: $1:$2 registry HEAD returned HTTP $code" >&2
+        *)       echo "warn: $1:$2 authenticated probe returned HTTP $code" >&2
                  return 2 ;;
     esac
 }


### PR DESCRIPTION
## Summary

Follow-up to #397. The OCI pushes themselves work again (the six fluxcd packages from #401 are on ghcr.io), but the issue is not fully closed — three remnants keep failing or neutering the workflows:

- **Publish Package runs fail and lose their Artifact Hub commit.** Several PRs merged in quick succession (13:01–13:04 on Aug 30) each triggered a publish run; every run's final `git push` of `.integration/artifacthub/*/artifacthub-pkg.yaml` was rejected with `! [rejected] main -> main (fetch first)`, so the runs went red and **no metadata commit landed on main** — Artifact Hub never learned about the new versions. (Runs [33313065139](https://github.com/kcl-lang/modules/actions/runs/33313065139), [33313131920](https://github.com/kcl-lang/modules/actions/runs/33313131920))
- **Scheduled Republish fails at login.** The nightly job dies with `failed to store the credentials for ghcr.io: putting plaintext credentials is disabled`. `kcl registry login` cannot work on a headless runner against an HTTPS registry: kpm only enables ORAS's `AllowPlaintextPut` under `OCI_REG_PLAIN_HTTP=on`, which also forces plain-HTTP transport. (Run [33354227555](https://github.com/kcl-lang/modules/actions/runs/33354227555), linked in #395)
- **The repush probe can never detect a missing package.** `image_exists` probes ghcr.io anonymously; ghcr answers 401 for both existing and missing tags (and 404 for existing tags without a proper `Accept` header). Both were verified with live requests. The script treats every non-200/404 as "transport error, skip", so the nightly job would greenly no-op even with login fixed.

## Changes

1. `update_metadata.yaml` + `update_specified_metadatas.yaml`: serialize in one `concurrency` group (`publish-package`, no cancel — cancelling would skip a publish) and `git pull --rebase origin main` before `git push`.
2. `scheduled-republish.yml`: drop `kcl registry login`; write the ghcr.io `auths` entry directly to `~/.docker/config.json` + `~/.kpm/config/config.json` — the same workaround #397 already proven in the Publish Package workflow.
3. `repush_not_exist.sh`: on 401, follow the `WWW-Authenticate` bearer challenge, fetch an anonymous pull token, and re-probe with it plus a manifest `Accept` header; a denied token request (ghcr returns HTTP 403 `DENIED` for a nonexistent repository) counts as missing — every package in this org is public.

The probe logic was tested live against ghcr.io: existing tag → rc 0, missing tag → rc 1, nonexistent repository → rc 1.

Upstream root cause of the login failure (AllowPlaintextPut gated behind the plain-HTTP flag) will be filed against kcl-lang/kpm separately.

## Test plan

- [ ] Watch the next merge of a `*.mod` change: Publish Package run goes green and a `chore: update artifacthub-pkg.yaml` commit lands on main
- [ ] `workflow_dispatch` the Scheduled Republish job: login step passes, summary shows non-zero `checked` with sensible `exists`/`missing` counts
- [ ] Confirm k8s 1.33 (#342) and anything else missing since July gets repushed by the nightly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)