### PR TITLE
fix(ci): probe ghcr.io with credentials in scheduled repush (follow-up to #403)

### DIFF
--- a/.github/workflows/scheduled-republish.yml
+++ b/.github/workflows/scheduled-republish.yml
@@ -71,6 +71,14 @@ jobs:
         env:
           KPM_REG: ghcr.io
           KPM_REPO: kcl-lang
+          # The probe authenticates with the same credentials kpm pushes
+          # with. Without them a package with restricted visibility on
+          # ghcr.io is indistinguishable from a missing one: the probe
+          # flags it, and kpm's push then rejects the repush with
+          # "package version already exists" (observed for gitlab-ci,
+          # gke.secret-sync and enkinex-odcs on the first run).
+          REG_USER: ${{ secrets.DEPLOY_ACCESS_NAME }}
+          REG_TOKEN: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
         run: ./scripts/repush_not_exist.sh
 
       - name: Annotate summary with run metadata

--- a/scripts/repush_not_exist.sh
+++ b/scripts/repush_not_exist.sh
@@ -9,6 +9,14 @@
 #   REG_HOST   OCI registry host (default: ghcr.io)
 #   REG_NS     registry namespace / org (default: kcl-lang)
 #   REG_SCHEME http(s) scheme for manifest lookup (default: https)
+#   REG_USER   optional registry username, REG_TOKEN the matching token.
+#              When set, the probe fetches its access token authenticated,
+#              so packages with restricted visibility (private on ghcr.io)
+#              are recognized as existing. Anonymous probes cannot tell a
+#              private package from a missing one and flag it for repush
+#              on every run; kpm's push then (correctly) rejects it with
+#              "package version already exists". kpm's own ContainsTag
+#              lists tags authenticated for the same reason.
 
 set -u
 set -o pipefail
@@ -16,6 +24,8 @@ set -o pipefail
 REG_HOST="${REG_HOST:-ghcr.io}"
 REG_NS="${REG_NS:-kcl-lang}"
 REG_SCHEME="${REG_SCHEME:-https}"
+REG_USER="${REG_USER:-}"
+REG_TOKEN="${REG_TOKEN:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUSH_SCRIPT="$SCRIPT_DIR/push_pkg_from.sh"
@@ -60,10 +70,13 @@ parse_kcl_mod() {
 #   with 401 + a WWW-Authenticate bearer challenge even for public
 #   packages, and return 401 for both existing and missing tags — a bare
 #   probe therefore cannot distinguish anything. Follow the challenge to
-#   obtain an anonymous pull token and re-probe with it. A denied token
-#   request (ghcr.io: HTTP 403, body {"errors":[{"code":"DENIED"}]} for a
-#   nonexistent repository) also counts as missing: every package in this
-#   org is public, so an inaccessible repo is a repo that is not there.
+#   obtain an anonymous pull token and re-probe with it. When REG_USER /
+#   REG_TOKEN are set the token request authenticates, so packages with
+#   restricted visibility are probed like kpm's own ContainsTag does. A
+#   denied token request (ghcr.io: HTTP 403, body
+#   {"errors":[{"code":"DENIED"}]}) counts as missing: with credentials
+#   supplied it means the repository does not exist; without them it can
+#   also mean the package is private, so pass credentials when in doubt.
 image_exists() {
     local name="$1" version="$2"
     local url="${REG_SCHEME}://${REG_HOST}/v2/${REG_NS}/$1/manifests/$2"
@@ -91,8 +104,13 @@ image_exists() {
     service=$(printf '%s\n' "$auth_header" | sed -n 's/.*service="\([^"]*\)".*/\1/p')
 
     token_url="${realm}?service=${service}&scope=repository:${REG_NS}/${name}:pull"
-    token=$(curl -sS --max-time 30 "$token_url" 2>/dev/null \
-                | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    if [ -n "$REG_USER" ] && [ -n "$REG_TOKEN" ]; then
+        token=$(curl -sS -u "${REG_USER}:${REG_TOKEN}" --max-time 30 "$token_url" 2>/dev/null \
+                    | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    else
+        token=$(curl -sS --max-time 30 "$token_url" 2>/dev/null \
+                    | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    fi
     if [ -z "$token" ]; then
         return 1
     fi


### PR DESCRIPTION
## Summary

Follow-up to #403, from the first real dispatch of the Scheduled Republish workflow ([run 33464660954](https://github.com/kcl-lang/modules/actions/runs/33464660954)):

- **The #403 fixes worked.** The login step passed, the probe found the packages missing since end of July, and **35 packages were restored** — all k8s versions 1.14–1.36 (incl. 1.33 from #342), external-secrets 2.9.0, the crossplane providers, and more. Summary: `checked 378 / exists 340 / missing 38 / pushed 35 / failed 3`.

- **The 3 failures were false positives on packages with restricted visibility.** `gitlab-ci:0.1.0`, `gke.secret-sync:1.34.8`, `enkinex-odcs:3.1.0`: ghcr.io denies an *anonymous* token request for them, so the probe's "denied ⇒ missing" assumption broke, the script queued them for repush, and kpm (correctly) refused with `package version already exists`. kpm's own `ContainsTag` never trips on this because it lists tags **authenticated**.

Fix: pass `REG_USER`/`REG_TOKEN` (the same `DEPLOY_ACCESS_*` secrets kpm pushes with) into `repush_not_exist.sh`, and use them for the token request when present. With valid credentials a denied token request genuinely means the repository is missing.

## Test plan

- [x] Probe re-verified live against ghcr.io anonymously: existing tag → rc 0, missing tag → rc 1, nonexistent repo → rc 1
- [x] Credential path exercised with bogus credentials (degrades to "missing" as expected when auth fails)
- [ ] After merge, dispatch Scheduled Republish again: expect `exists 343 / missing 35 / pushed 0 / failed 0` and a green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)